### PR TITLE
add status and created_at index to items table

### DIFF
--- a/isucari/webapp/sql/01_schema.sql
+++ b/isucari/webapp/sql/01_schema.sql
@@ -30,7 +30,8 @@ CREATE TABLE `items` (
   `category_id` int unsigned NOT NULL,
   `created_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `updated_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  INDEX idx_category_id (`category_id`)
+  INDEX idx_category_id (`category_id`),
+  INDEX idx_status_and_created_at (`status`, `created_at`)
 ) ENGINE=InnoDB DEFAULT CHARACTER SET utf8mb4;
 
 DROP TABLE IF EXISTS `transaction_evidences`;


### PR DESCRIPTION
https://github.com/zuckeyM-17/isucon9q-r/pull/10#issuecomment-549113431

これとおんなじところで、

statusでwhere句かけてcreated_atでorder by(where句で使ってることろもある)しているので、status => created_atの順で indexを貼っています。